### PR TITLE
Add purple universe background

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { ReactNode, useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 import AuroraBackground from './AuroraBackground';
+import UniverseBackground from './UniverseBackground';
 
 interface LayoutProps {
   children: ReactNode;
@@ -13,6 +14,7 @@ const Layout = ({ children }: LayoutProps) => {
   const [open, setOpen] = useState(false);
   return (
     <div className="relative min-h-screen flex flex-col bg-gradient-to-br from-indigo-200 via-white to-cyan-200 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 text-foreground">
+      <UniverseBackground />
       <AuroraBackground />
       <header className="glass shadow-md sticky top-0 z-20">
         <div className="container mx-auto flex items-center justify-between px-4 sm:px-6 py-3">

--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+/**
+ * Star-filled purple universe background used behind the main layout.
+ */
+const UniverseBackground: React.FC = () => (
+  <div className="pointer-events-none absolute inset-0 -z-20 overflow-hidden">
+    {/* Deep purple gradient */}
+    <div className="absolute inset-0 bg-gradient-to-br from-purple-800 via-fuchsia-900 to-black" />
+    {/* Star field overlay */}
+    <div className="absolute inset-0 bg-stars opacity-50" />
+  </div>
+);
+
+export default UniverseBackground;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -76,14 +76,23 @@ body {
 
 /* Glassmorphism utility */
 .glass {
-  background: rgba(255, 255, 255, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: rgba(255, 255, 255, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border-radius: 1rem;
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
 }
 .dark .glass {
-  background: rgba(0, 0, 0, 0.3);
-  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Star field background */
+.bg-stars {
+  background-image: radial-gradient(rgba(255, 255, 255, 0.7) 1px, transparent 1px),
+    radial-gradient(rgba(255, 255, 255, 0.5) 1px, transparent 1px);
+  background-size: 40px 40px, 80px 80px;
+  background-position: 0 0, 20px 20px;
 }
 


### PR DESCRIPTION
## Summary
- enhance the glassmorphism effect
- add star field styles and new `UniverseBackground` component
- use the universe background across all pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68743891f65483289a87627d89d1457c