### PR TITLE
Implement permanent dark theme with orbiting stars

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link';
 import { ReactNode, useState } from 'react';
 import { Menu, X } from 'lucide-react';
-import ThemeToggle from './ThemeToggle';
 import AuroraBackground from './AuroraBackground';
 import UniverseBackground from './UniverseBackground';
 
@@ -33,9 +32,6 @@ const Layout = ({ children }: LayoutProps) => {
             </Link>
           </nav>
           <div className="flex items-center space-x-4 ml-auto">
-            <div className="hidden sm:block">
-              <ThemeToggle />
-            </div>
             <button
               aria-label="Toggle Menu"
               onClick={() => setOpen(!open)}
@@ -58,9 +54,6 @@ const Layout = ({ children }: LayoutProps) => {
                 Contact
               </Link>
             </nav>
-            <div className="pt-2">
-              <ThemeToggle />
-            </div>
           </div>
         )}
       </header>

--- a/src/components/UniverseBackground.tsx
+++ b/src/components/UniverseBackground.tsx
@@ -4,11 +4,10 @@ import React, { useEffect, useRef } from 'react';
  * Star-filled purple universe background used behind the main layout.
  */
 interface Star {
-  x: number;
-  y: number;
-  r: number;
-  vx: number;
-  vy: number;
+  radius: number;
+  angle: number;
+  size: number;
+  speed: number;
 }
 
 const UniverseBackground: React.FC = () => {
@@ -30,30 +29,27 @@ const UniverseBackground: React.FC = () => {
     window.addEventListener('resize', resize);
 
     const createStar = (): Star => ({
-      x: Math.random() * canvas.width,
-      y: Math.random() * canvas.height,
-      r: Math.random() * 1.5 + 0.5,
-      vx: (Math.random() - 0.5) * 0.2,
-      vy: (Math.random() - 0.5) * 0.2,
+      radius: Math.random() * Math.min(canvas.width, canvas.height) * 0.5,
+      angle: Math.random() * Math.PI * 2,
+      size: Math.random() * 1.5 + 0.5,
+      speed: Math.random() * 0.001 + 0.0005,
     });
 
-    const stars: Star[] = Array.from({ length: 150 }, createStar);
+    const stars: Star[] = Array.from({ length: 200 }, createStar);
 
     let animationId: number;
     const draw = () => {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.fillStyle = '#fff';
+      const cx = canvas.width / 2;
+      const cy = canvas.height / 2;
       stars.forEach((s) => {
-        s.x += s.vx;
-        s.y += s.vy;
-
-        if (s.x < 0) s.x = canvas.width;
-        if (s.x > canvas.width) s.x = 0;
-        if (s.y < 0) s.y = canvas.height;
-        if (s.y > canvas.height) s.y = 0;
+        s.angle += s.speed;
+        const x = cx + Math.cos(s.angle) * s.radius;
+        const y = cy + Math.sin(s.angle) * s.radius;
 
         ctx.beginPath();
-        ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+        ctx.arc(x, y, s.size, 0, Math.PI * 2);
         ctx.fill();
       });
       animationId = requestAnimationFrame(draw);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,14 +1,11 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
-import { ThemeProvider } from "@/context/ThemeContext";
 import Layout from "@/components/Layout";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <ThemeProvider>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
-    </ThemeProvider>
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html lang="en" className="dark">
         <Head>
         <meta name="description" content="Gabriel Temtsen | Fullstack Developer" key="desc" />
         <meta property="og:title" content="Gabe Dev | Open Source Dev" />


### PR DESCRIPTION
## Summary
- remove theme provider and toggle to keep dark theme always
- enforce `class="dark"` on the `<Html>` element
- add star orbit animation for the universe background

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687cf1bd5d5c8328a782729dcd7d69a0