### PR TITLE
feat: add theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Welcome to my portfolio! Here you'll find information about my projects, skills,
 
 I am a passionate developer with experience in various technologies and a strong desire to learn and grow in the field of software development.
 
+## Features
+
+- Toggle between light and dark themes to view the portfolio in your preferred style.
+
 ## Projects
 
 ## Skills

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { ReactNode, useState } from 'react';
 import { Menu, X } from 'lucide-react';
 import AuroraBackground from './AuroraBackground';
 import UniverseBackground from './UniverseBackground';
+import ThemeToggle from './ThemeToggle';
 
 interface LayoutProps {
   children: ReactNode;
@@ -32,6 +33,7 @@ const Layout = ({ children }: LayoutProps) => {
             </Link>
           </nav>
           <div className="flex items-center space-x-4 ml-auto">
+            <ThemeToggle />
             <button
               aria-label="Toggle Menu"
               onClick={() => setOpen(!open)}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 import Layout from "@/components/Layout";
+import { ThemeProvider } from "@/context/ThemeContext";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <ThemeProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </ThemeProvider>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,8 +2,8 @@ import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html lang="en" className="dark">
-        <Head>
+    <Html lang="en">
+      <Head>
         <meta name="description" content="Gabriel Temtsen | Fullstack Developer" key="desc" />
         <meta property="og:title" content="Gabe Dev | Open Source Dev" />
         <meta
@@ -13,6 +13,20 @@ export default function Document() {
         <meta
           property="og:image"
           content="/gabbyProf.jpeg"
+        />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              (function() {
+                try {
+                  const theme = localStorage.getItem('theme');
+                  if (theme === 'dark') {
+                    document.documentElement.classList.add('dark');
+                  }
+                } catch (_) {}
+              })();
+            `,
+          }}
         />
       </Head>
       <body className="antialiased">


### PR DESCRIPTION
## Summary
- wire up ThemeProvider and ThemeToggle to enable light/dark mode
- persist theme between visits and describe the feature in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e72940e34832885cd31969b4a28d3