### PR TITLE
Validate contact form field lengths

### DIFF
--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -11,6 +11,9 @@ interface ContactResponse {
 }
 
 const isValidEmail = (email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+const MAX_NAME_LENGTH = 100;
+const MAX_EMAIL_LENGTH = 254;
+const MAX_MESSAGE_LENGTH = 2000;
 
 const buildEmailHtml = (name: string, email: string, message: string) => `
   <div style="font-family: Arial, sans-serif; font-size: 16px; color: #1f2937;">
@@ -32,8 +35,29 @@ export default async function handler(
   }
 
   const { name = '', email = '', message = '' } = req.body as ContactRequestBody;
+  const trimmedName = name.trim();
+  const trimmedEmail = email.trim();
+  const trimmedMessage = message.trim();
 
-  if (!name.trim() || !message.trim() || !isValidEmail(email)) {
+  if (trimmedName.length > MAX_NAME_LENGTH) {
+    return res.status(400).json({
+      message: `Name must be ${MAX_NAME_LENGTH} characters or fewer.`,
+    });
+  }
+
+  if (trimmedEmail.length > MAX_EMAIL_LENGTH) {
+    return res.status(400).json({
+      message: `Email must be ${MAX_EMAIL_LENGTH} characters or fewer.`,
+    });
+  }
+
+  if (trimmedMessage.length > MAX_MESSAGE_LENGTH) {
+    return res.status(400).json({
+      message: `Message must be ${MAX_MESSAGE_LENGTH} characters or fewer.`,
+    });
+  }
+
+  if (!trimmedName || !trimmedMessage || !isValidEmail(trimmedEmail)) {
     return res
       .status(400)
       .json({ message: 'Please provide a valid name, email, and message.' });
@@ -58,10 +82,10 @@ export default async function handler(
       body: JSON.stringify({
         from: 'Portfolio Contact Form <onboarding@resend.dev>',
         to: ['gabrieltemtsen@gmail.com'],
-        reply_to: email,
-        subject: `New message from ${name}`,
-        html: buildEmailHtml(name, email, message),
-        text: `Name: ${name}\nEmail: ${email}\nMessage:\n${message}`,
+        reply_to: trimmedEmail,
+        subject: `New message from ${trimmedName}`,
+        html: buildEmailHtml(trimmedName, trimmedEmail, trimmedMessage),
+        text: `Name: ${trimmedName}\nEmail: ${trimmedEmail}\nMessage:\n${trimmedMessage}`,
       }),
     });
 


### PR DESCRIPTION
### Motivation

- Prevent excessively long input for the contact API by enforcing reasonable limits on `name`, `email`, and `message` to reduce abuse and ensure downstream email payloads remain safe.
- Trim whitespace before validation so accidental leading/trailing spaces don't trigger validation errors or get included in emails.

### Description

- Added constants `MAX_NAME_LENGTH`, `MAX_EMAIL_LENGTH`, and `MAX_MESSAGE_LENGTH` to `src/pages/api/contact.ts` and applied length checks that return `400` with clear messages when limits are exceeded.
- Trimmed incoming fields into `trimmedName`, `trimmedEmail`, and `trimmedMessage`, and updated validation to use the trimmed values with the existing `isValidEmail` check.
- Updated the email payload to use the trimmed values for `reply_to`, `subject`, `html`, and `text` so sent messages reflect the validated input.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9873d3888328a15001bd1562995e)